### PR TITLE
Module Spec Generation and Auto Doc in Verilog Code

### DIFF
--- a/magia/bundle.py
+++ b/magia/bundle.py
@@ -289,6 +289,10 @@ class IOBundle:
         return self._output_names
 
     @property
+    def signals(self) -> SignalDict:
+        return self._signals
+
+    @property
     def owner_instance(self) -> Optional["Instance"]:
         return self._owner_instance
 

--- a/magia/core.py
+++ b/magia/core.py
@@ -15,6 +15,7 @@ class SignalConfig:
     width: int = 0
     signed: bool = False
     signal_type: SignalType = SignalType.WIRE
+    description: str = ""
 
     # The module instance that owns this signal
     # Applicable to input / output ports only
@@ -104,6 +105,7 @@ class Signal(Synthesizable):
             width: int = 0, signed: bool = False,
             name: Optional[str] = None,
             parent_bundle: Optional["SignalBundle"] = None,
+            description: Optional[str] = None,
             **kwargs
     ):
         if name is None:
@@ -115,6 +117,7 @@ class Signal(Synthesizable):
             width=width,
             signed=signed,
             parent_bundle=parent_bundle,
+            description="" if description is None else description,
         )
         self._drivers = SignalDict()
 
@@ -135,6 +138,13 @@ class Signal(Synthesizable):
         Short name of the signal, is used to identify the signal in a bundle / SignalDict
         """
         return self._config.name
+
+    @property
+    def description(self) -> str:
+        """
+        Description of the signal
+        """
+        return self._config.description
 
     @property
     def type(self) -> SignalType:
@@ -594,6 +604,7 @@ class Input(Signal):
             name=self.name,
             width=len(self),
             signed=self.signed,
+            description=self.description,
             owner_instance=owner_instance,
         )
 
@@ -647,6 +658,7 @@ class Output(Signal):
             name=self.name,
             width=len(self),
             signed=self.signed,
+            description=self.description,
             owner_instance=owner_instance,
         )
 

--- a/magia/external.py
+++ b/magia/external.py
@@ -75,8 +75,6 @@ class ExternalModule(Module):
         for port in self.ports_from_code:
             self.io += self._create_port(port)
 
-        self.register_module_doc(locals())
-
     def elaborate(self) -> tuple[str, set[Module]]:
         mod_decl = self.mod_declaration()
         mod_end = "endmodule"

--- a/magia/std/storage.py
+++ b/magia/std/storage.py
@@ -6,7 +6,6 @@ from .bundles import StdIO
 class Queue(Module):
     def __init__(self, width, depth, **kwargs):
         super().__init__(**kwargs)
-        self.register_module_doc(locals())
 
         self.width = width
         self.depth = depth

--- a/tests/test_module_instance.py
+++ b/tests/test_module_instance.py
@@ -122,6 +122,7 @@ def test_elaborate_doc():
         """
         This is a top module.
         """
+
         def __init__(self, width, **kwargs):
             super().__init__(**kwargs)
             self.io += Input("a", width)
@@ -131,3 +132,35 @@ def test_elaborate_doc():
     doc = Elaborator.to_string(Top(width=7086))
     assert "This is a top module." in doc, "Module doc is missing."
     assert "width: 7086" in doc, "Module parameter is missing."
+
+
+def test_module_spec():
+    class Top(Module):
+        """
+        This is a top module.
+        """
+
+        def __init__(self, width, **kwargs):
+            """
+            :param width: The width of the module.
+            """
+            super().__init__(**kwargs)
+            self.io += Input("a", width, description="Input A")
+            self.io += Output("b", width)
+            self.io.b <<= self.io.a
+
+    spec = Top(width=7086, name="TopLevel").spec
+    assert spec["name"] == "TopLevel"
+    assert spec["description"] == "This is a top module."
+    assert spec["parameters"][0]["name"] == "width"
+    assert spec["parameters"][0]["value"] == 7086
+    assert spec["parameters"][0]["description"] == "The width of the module."
+    for port in spec["ports"]:
+        assert port["name"] in ["a", "b"]
+        assert port["width"] == 7086
+        if port["name"] == "a":
+            assert port["direction"] == "INPUT"
+            assert port["description"] == "Input A"
+        else:
+            assert port["direction"] == "OUTPUT"
+            assert port["description"] == ""

--- a/tests/test_module_instance.py
+++ b/tests/test_module_instance.py
@@ -115,3 +115,19 @@ def test_elaborate_to_files(temp_build_dir):
         if line.strip() == "endmodule"
     ]
     assert len(end_modules) == 6, f"Expected 6 modules in {adder_file}, got {len(end_modules)}."
+
+
+def test_elaborate_doc():
+    class Top(Module):
+        """
+        This is a top module.
+        """
+        def __init__(self, width, **kwargs):
+            super().__init__(**kwargs)
+            self.io += Input("a", width)
+            self.io += Output("b", width)
+            self.io.b <<= self.io.a
+
+    doc = Elaborator.to_string(Top(width=7086))
+    assert "This is a top module." in doc, "Module doc is missing."
+    assert "width: 7086" in doc, "Module parameter is missing."


### PR DESCRIPTION
- Auto Insert Documentation into the elaborated code

Done automatically during elaboration and No extra syntax is required.

Removing `Module.register_module_doc()` due to redundancy
|Py|Sv|
|----|----|
|![image](https://github.com/khwong-c/syn-magia/assets/92428218/6c44192e-8ad2-4703-824a-1e4030719ce4)|![image](https://github.com/khwong-c/syn-magia/assets/92428218/e7f1c339-6657-44f9-a531-629d31e81fd6)|

- Module Spec Generation
  - Using `Module().spec` to describe a specialized module in a `dict`.
  - Obtain Module Description from Module Docstring
  - Obtain Parameter Description from `Module().__init__()` Docstring
  - Add `Signal.description` for Port Description. (i.e. `Input` and `Output` at the same time)

e.g. Output the spec of a module and further output it as a YAML file
| Py | YAML Spec |
|----|---|
|![image](https://github.com/khwong-c/syn-magia/assets/92428218/2f91bc47-a677-4832-be6f-b24d558dbd1f)|![image](https://github.com/khwong-c/syn-magia/assets/92428218/afeeb028-e071-4212-94f9-ac1724005e61)|